### PR TITLE
Add configurable dlOpenMode for DLKit.load(dylib:)

### DIFF
--- a/Sources/DLKit/DLKit.swift
+++ b/Sources/DLKit/DLKit.swift
@@ -60,12 +60,17 @@ public struct DLKit {
     }
     public static let RTLD_DEFAULT = UnsafeMutableRawPointer(bitPattern: -2)
     public static let RTLD_MAIN_ONLY = UnsafeMutableRawPointer(bitPattern: -5)
+    /// Mode flags passed to `dlopen` by `DLKit.load(dylib:)`.
+    /// Default preserves historical behaviour (`RTLD_NOW`). Override
+    /// to change symbol binding/visibility of loaded images, e.g.
+    /// `DLKit.dlOpenMode = RTLD_LAZY | RTLD_GLOBAL`.
+    public static var dlOpenMode: Int32 = RTLD_NOW
     public static var logger = { (msg: String) in
         NSLog("DLKit: %@", msg)
     }
     public static func load(dylib: String) -> ImageSymbols? {
         let index = imageCount
-        guard let handle = dlopen(dylib, RTLD_NOW) else {
+        guard let handle = dlopen(dylib, dlOpenMode) else {
             logger("⚠️ dlopen failed \(String(cString: dlerror()))")
             return nil
         }


### PR DESCRIPTION
## Summary

Adds a single public overridable static to `DLKit` that lets consumers control the flags passed to `dlopen` when `DLKit.load(dylib:)` loads an image. **No behaviour change by default** — existing callers keep `RTLD_NOW`.

```swift
/// Mode flags passed to `dlopen` by `DLKit.load(dylib:)`.
/// Default preserves historical behaviour (`RTLD_NOW`). Override
/// to change symbol binding/visibility of loaded images, e.g.
/// `DLKit.dlOpenMode = RTLD_LAZY | RTLD_GLOBAL`.
public static var dlOpenMode: Int32 = RTLD_NOW
```

```swift
guard let handle = dlopen(dylib, dlOpenMode) else { … }
```

## Motivation

Requested in johnno1962/InjectionNext#131:

> one idea might be to create a new public static var dlOpenMode = RTLD_LAZY | RTLD_GLOBAL used in the dlopen so people can override it.

Different consumers need different semantics:

| Mode                          | When it helps                                                                 |
| ----------------------------- | ----------------------------------------------------------------------------- |
| `RTLD_NOW` *(default)*        | Current DLKit behaviour. Eager binding, per-image scope.                      |
| `RTLD_LAZY \| RTLD_GLOBAL`    | Hot-reload tools (InjectionNext) where later-loaded dylibs resolve symbols against previously-injected ones. |
| `RTLD_NOW \| RTLD_GLOBAL`     | Diagnosing failed injections — surfaces missing symbols at load time while still exposing them globally. |
| `RTLD_LAZY \| RTLD_LOCAL`     | Plugin hosts that want strict isolation per-dylib.                            |

Previously the only way to change this was to fork DLKit. This PR lifts that restriction without touching any call site.

## Backwards compatibility

- Default flags unchanged (`RTLD_NOW`) — any existing caller behaves identically.
- No new imports, no new C types, no API additions beyond the one static `var`.
- Swift 5 language mode preserved. No `@MainActor` / `Sendable` / strict-concurrency requirements introduced.
- Thread-safety note: `dlOpenMode` is a plain `static var`, matching the existing pattern of `DLKit.logger`. Callers are expected to set it during setup (not concurrently with `load(dylib:)`).

## Downstream consumer

InjectionNext will set `DLKit.dlOpenMode = RTLD_LAZY | RTLD_GLOBAL` during launch and expose a user-facing picker (Lazy+Global / Now+Global) under **Settings › Advanced › Dynamic Loader**. Tracking PR: johnno1962/InjectionNext#135.

## Test plan

- [x] Builds on macOS with Swift 5 (no Swift 6 concurrency requirements).
- [x] `DLKit.load(dylib:)` loads frameworks with the default `RTLD_NOW` (behaviour identical to pre-PR).
- [x] Setting `DLKit.dlOpenMode = RTLD_LAZY | RTLD_GLOBAL` before `load(dylib:)` results in the override flags being passed to `dlopen` (verified in InjectionNext integration).
- [x] Restoring `DLKit.dlOpenMode = RTLD_NOW` after an override works as expected.